### PR TITLE
Version of adding -std=c99 that works in cmake 3.2.2 

### DIFF
--- a/pachi_py/pachi/CMakeLists.txt
+++ b/pachi_py/pachi/CMakeLists.txt
@@ -3,6 +3,19 @@
 cmake_minimum_required(VERSION 2.8)
 project(pachi)
 
+# From http://stackoverflow.com/questions/24840030/forcing-c99-in-cmake-to-use-for-loop-initial-declaration
+macro(use_c99)
+  if (CMAKE_VERSION VERSION_LESS "3.1")
+    if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+      set (CMAKE_C_FLAGS "--std=c99 ${CMAKE_C_FLAGS}")
+    endif ()
+  else ()
+    set (CMAKE_C_STANDARD 99)
+  endif ()
+endmacro(use_c99)
+
+use_c99()
+
 # http://cmake.3232098.n2.nabble.com/Default-value-for-CMAKE-BUILD-TYPE-td7550756.html
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to 'Release' as none was specified.")
@@ -21,7 +34,6 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
     CACHE PATH "Output directory for executables and DLL's.")
 
-list(APPEND CMAKE_C_FLAGS "-std=c99")
 list(APPEND CMAKE_CXX_FLAGS "-std=c++11")
 
 # list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
Comments refer to 9b13f2b62733cf455747b5bba7c4bf8cab3f4d10 :

The 'list(APPEND CMAKE_C_FLAGS "-std=c99")' line in pachi_py/pachi/CMakelists.txt causes cmake to emit a semi-colon before that part, breaking the build  (ie

```
make VERBOSE=1
/usr/bin/cmake -H/usr/src/machinelearning/pachi-py/pachi_py/pachi -B/usr/src/machinelearning/pachi-py/pachi_py/build --check-build-system CMakeFiles/Makefile.cmake 0
/usr/bin/cmake -E cmake_progress_start /usr/src/machinelearning/pachi-py/pachi_py/build/CMakeFiles /usr/src/machinelearning/pachi-py/pachi_py/build/CMakeFiles/progress.marks
make -f CMakeFiles/Makefile2 all
make[1]: Entering directory '/usr/src/machinelearning/pachi-py/pachi_py/build'
make -f CMakeFiles/pachi.dir/build.make CMakeFiles/pachi.dir/depend
make[2]: Entering directory '/usr/src/machinelearning/pachi-py/pachi_py/build'
cd /usr/src/machinelearning/pachi-py/pachi_py/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /usr/src/machinelearning/pachi-py/pachi_py/pachi /usr/src/machinelearning$
make[2]: Leaving directory '/usr/src/machinelearning/pachi-py/pachi_py/build'
make -f CMakeFiles/pachi.dir/build.make CMakeFiles/pachi.dir/build
make[2]: Entering directory '/usr/src/machinelearning/pachi-py/pachi_py/build'
/usr/bin/cmake -E cmake_progress_report /usr/src/machinelearning/pachi-py/pachi_py/build/CMakeFiles 1
[  2%] Building C object CMakeFiles/pachi.dir/board.c.o
/usr/bin/cc   -O2 -march=native -mtune=native ;-std=c99 -O3 -DNDEBUG -I/usr/src/machinelearning/pachi-py/pachi_py/pachi    -fPIC "-D_GNU_SOURCE -Wall -Wextra -Wno-unused-functio$
cc: fatal error: no input files
```

Note the semi-colon in between -mtune=native  and -std=c99 on the second last line. This is probably due to version-specific differences in cmake. I'm running cmake 3.2.2 (Ubuntu 15.10). 

Patch changes it to code that should work on older and newer versions of cmake taken from David Grayson on stackoverflow (http://stackoverflow.com/questions/24840030/forcing-c99-in-cmake-to-use-for-loop-initial-declaration)
