### PR TITLE
Remove the numpy pre-install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,20 @@
-from distutils.command.build import build as DistutilsBuild
+from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools import setup, Extension
 import subprocess
 
-class FakeNumpy(object):
-  def get_include(self):
-    raise Exception('Tried to compile pachi-py, but numpy is not installed. HINT: Please install numpy separately before attempting this -- `pip install numpy` should do it.')
-
-try:
-  import numpy
-except Exception as e:
-  print('Failed to load numpy: {}. Numpy must be already installed to normally set up pachi-py. Trying to actually build pachi-py will result in an error.'.format(e))
-  numpy = FakeNumpy()
-
-
 # For building Pachi as a library
-class BuildLibPachi(DistutilsBuild):
+class BuildLibPachi(_build_ext):
     def run(self):
         try:
             subprocess.check_call("cd pachi_py; mkdir -p build && cd build && cmake ../pachi && make -j4", shell=True)
         except subprocess.CalledProcessError as e:
             print("Could not build pachi-py: %s" % e)
             raise
-        DistutilsBuild.run(self)
+        # Prevent numpy from trying to setup
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
+        _build_ext.run(self)
 
 # Cython recommands checking in the Cython-generated C files
 # (cf. http://stackoverflow.com/a/19138055).
@@ -33,7 +26,7 @@ ext = Extension(
     name="pachi_py.cypachi",
     sources=["pachi_py/cypachi.cpp", "pachi_py/goutil.cpp"],
     language="c++",
-    include_dirs=[numpy.get_include(), "pachi_py/pachi"],
+    include_dirs=["pachi_py/pachi"],
     libraries=["pachi"],
     library_dirs=["pachi_py/build/lib"], # this is the output dir of BuildLibPachi
     extra_compile_args=["-std=c++11"],
@@ -46,7 +39,7 @@ setup(name='pachi-py',
       author='OpenAI',
       author_email='info@openai.com',
       packages=['pachi_py'],
-      cmdclass={'build': BuildLibPachi},
+      cmdclass={'build_ext': BuildLibPachi},
       setup_requires=['numpy'],
       install_requires=['numpy'],
       tests_require=['nose2'],

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ envlist = py27, py35
 whitelist_externals=make
 deps =
     nose2
-    numpy
 commands =
     python setup.py build
     pip install -e .
@@ -23,7 +22,7 @@ whitelist_externals=make
                     echo
 install_command=echo {packages}
 commands =
-    pip install numpy nose2
+    pip install nose2
     python setup.py build
     pip install -e .
     nose2


### PR DESCRIPTION
Right now, to build pachi-py, you need to already have numpy installed.
This makes installing this package messy, and makes all packages that
include pachi-py inherit the same messiness.

I found @coldfix's StackOverflow post on this subject and it seems to
solve the problem. http://stackoverflow.com/a/21621689/4951255

This closes openai/pachi-py#3
